### PR TITLE
fix: fonts lfs issue

### DIFF
--- a/fonts/NotoSansTC-Bold.ttf
+++ b/fonts/NotoSansTC-Bold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:071ba8a6fd5c290c5efa85da561020fa423cfc7342c67152b6cb00e5012a107c
+size 7105312

--- a/fonts/NotoSansTC-Regular.ttf
+++ b/fonts/NotoSansTC-Regular.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b137e2eb57a2d1e4cf391c886ab1b783a0e5ddb5c75254748bde00c15cb8ff5
+size 7110560


### PR DESCRIPTION
Issue: [git lfs cannot discard file changes (encountered files that should have been pointers)](https://stackoverflow.com/questions/71236993/git-lfs-cannot-discard-file-changes-encountered-files-that-should-have-been-poi)

Seems that font files on GitHub didn't apply git LFS...
So I remove the file and readd them to get LFS applied.