### PR TITLE
fix: Add zh region hreflang attribute

### DIFF
--- a/src/components/app/head/DefaultHead.astro
+++ b/src/components/app/head/DefaultHead.astro
@@ -1,7 +1,7 @@
 ---
 import { SEO } from 'astro-seo';
 import type { GlobalHead } from '@/types';
-import { languageTags, prefixDefaultLocale } from '@/utils/i18n.ts';
+import { languageTags, regionTags, prefixDefaultLocale } from '@/utils/i18n.ts';
 import { currentLocaleWebsiteConfig } from '@/utils/getWebsiteConfig.ts';
 import { type LanguageKey } from '@/utils/i18n.ts';
 
@@ -71,7 +71,17 @@ function getPathnameWithoutLocale(pathname: string) {
               Astro.site
             ).toString()
           },
-          // Language Alternates
+
+          // Language Alternates - Region
+          ...Object.keys(regionTags).map(tag => ({
+            rel: "alternate",
+            hreflang: tag,
+            href: new URL(Astro.url.pathname,
+              Astro.site
+            ).toString()
+          })),
+
+          // Language Alternates - Countries
           ...Object.keys(languageTags).map(tag => ({
             rel: "alternate",
             hreflang: tag,
@@ -81,6 +91,7 @@ function getPathnameWithoutLocale(pathname: string) {
               Astro.site
             ).toString()
           })),
+
           // RSS Autodiscovery
           // https://www.rssboard.org/rss-autodiscovery
           {

--- a/src/components/app/head/DefaultHead.astro
+++ b/src/components/app/head/DefaultHead.astro
@@ -73,13 +73,17 @@ function getPathnameWithoutLocale(pathname: string) {
           },
 
           // Language Alternates - Region
-          ...Object.keys(regionTags).map(tag => ({
+          ...(Object.keys(regionTags) as Array<keyof typeof regionTags>).map(tag => {
+            const regionMap = {
+              zh: 'zh-tw' 
+            }
+            return ({
             rel: "alternate",
             hreflang: tag,
-            href: new URL(Astro.url.pathname,
+            href: new URL(regionMap[tag] + getPathnameWithoutLocale(Astro.url.pathname),
               Astro.site
             ).toString()
-          })),
+          })}),
 
           // Language Alternates - Countries
           ...Object.keys(languageTags).map(tag => ({

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -19,6 +19,11 @@ export const languageTags = {
   'zh-tw': 'zh-Hant-TW',
 } as const;
 
+// To address Missing region-independant link for that language Problem, Here's a table storing existing region data
+export const regionTags = {
+  zh: 'zh-Hant-TW',
+} as const;
+
 export const defaultLocale = 'zh-tw';
 export const prefixDefaultLocale = false;
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced `regionTags` to handle missing region-independent links for the `zh` language.
- Updated `DefaultHead.astro` to include hreflang attributes for region-specific languages.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>i18n.ts</strong><dd><code>Add region-specific language handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/i18n.ts

<li>Added <code>regionTags</code> constant to store region-specific language data.<br> <li> Enhanced language handling for the <code>zh</code> region.<br>


</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/139/files#diff-648766b39e18e48addc4d75d1e8c92235f724796ffb67e8e84d8b08aaf437faa">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DefaultHead.astro</strong><dd><code>Implement hreflang for region-specific languages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/app/head/DefaultHead.astro

<li>Imported <code>regionTags</code> to manage hreflang attributes.<br> <li> Implemented hreflang attributes for region-specific languages.<br>


</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/139/files#diff-1da650d9e8cc1921f1b6fae3ab157e2592c662901d0d11ce3749fd74891d6c61">+13/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information