### PR TITLE
ci: Specify current deploy branch, avoid default to main and push to prod

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -151,4 +151,5 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: astro-blog
           directory: dist
+          branch: ${{ github.ref_name }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a new `branch` parameter in the deploy pipeline to specify the current deploy branch.
- This change avoids defaulting to `main`, ensuring deployments go to the correct environment.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-pipeline.yml</strong><dd><code>Enhance deployment workflow to specify branch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-pipeline.yml

<li>Added a new input parameter <code>branch</code> to specify the current deploy <br>branch.<br> <li> This change prevents defaulting to <code>main</code> and allows for more flexible <br>deployment.<br>


</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/141/files#diff-2c76ae7ee006442bc71c4239c84e44134450726e91c9c3d80f01df9348643991">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information