### PR TITLE
fix: Avoid duplicate search

### DIFF
--- a/src/pages/[language]/post/[...slug].astro
+++ b/src/pages/[language]/post/[...slug].astro
@@ -61,7 +61,7 @@ const { postLastModifiedDateUrl } = (await currentLocaleWebsiteConfig(Astro.curr
   <Container>
     <main class="mt-0 pt-8 px-2 sm:mt-[var(--mainNav-height)]">
       <article
-        data-pagefind-body
+        data-pagefind-body={Astro.currentLocale !== defaultLocale || undefined}
         data-article
         data-cy="post-content"
         class=`article-grid [grid-template-columns:1fr_min(65ch,_100%)_1fr] lg:px-auto prose mb-16 block w-full max-w-none md:prose-xl lg:grid ${rehypeAutoLinkStyle}`


### PR DESCRIPTION
### **User description**
(/ and /zh-tw) has same content will cause duplicated search result


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced search functionality by preventing duplicate search results for locales with the same content.
- Updated the `data-pagefind-body` attribute to conditionally set its value based on the current locale.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>[...slug].astro</strong><dd><code>Improve search result handling for duplicate content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/[language]/post/[...slug].astro

<li>Updated <code>data-pagefind-body</code> attribute to conditionally include value.<br> <li> Prevents duplicate search results for locales with identical content.<br>


</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/142/files#diff-38c34f86b269b29bbac255d73a7d8b1e0a5dd57996c85e9777177d01da7baf5f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information