### PR TITLE
ci: Avoid cypress binary missing

### DIFF
--- a/.github/workflows/testing-and-deploy-pipeline.yml
+++ b/.github/workflows/testing-and-deploy-pipeline.yml
@@ -50,7 +50,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: package.json
-          cache: 'pnpm'
+          # To avoid missing Cypress binrary, Skip Cahce Here, cypress-io/github-action has it's cache on node_moduels too
+          # cache: 'pnpm'
+
       # 1. List all LFS files
       # 2. Extract the first column (ID)
       # 3. Sort the IDs


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the CI configuration to prevent issues with the Cypress binary.
- Skipped caching for pnpm to ensure Cypress binaries are correctly installed.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>testing-and-deploy-pipeline.yml</strong><dd><code>Update CI configuration to avoid Cypress binary issues</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/testing-and-deploy-pipeline.yml

<li>Commented out the cache setting for pnpm.<br> <li> Added comments explaining the reason for skipping the cache.<br>


</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/152/files#diff-c54a458460109ac1dc90c93a35e00c1d2d255c54bdf615b3d2901cb588ffa7c5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information