### PR TITLE
feat: Avoid capitalize category & tags

### DIFF
--- a/src/components/post/CategoryList.astro
+++ b/src/components/post/CategoryList.astro
@@ -12,7 +12,7 @@ const translatedCategory = translateCategory(category || Astro.currentLocale as 
 
 <CategoryElement
   data-astro-prefetch
-  class="p-1.5 relative flex gap-1 mr-4 whitespace-nowrap capitalize opacity-60 hover:opacity-100"
+  class="p-1.5 relative flex gap-1 mr-4 whitespace-nowrap opacity-60 hover:opacity-100"
   {...categoryHref && {
     href: categoryHref,
   }}

--- a/src/components/post/TagsList.astro
+++ b/src/components/post/TagsList.astro
@@ -11,13 +11,13 @@ const { tags, tagHrefs } = Astro.props;
   {
     tagHrefs ? tagHrefs.map((href, index) => (
       <li data-cy="tag">
-        <a data-cy="tag-link" data-astro-prefetch class="p-1.5 flex gap-1 capitalize opacity-60 hover:opacity-100" {href}>
+        <a data-cy="tag-link" data-astro-prefetch class="p-1.5 flex gap-1 opacity-60 hover:opacity-100" {href}>
           <span>#</span><span data-pagefind-filter={`${`${m.teary_wide_impala_coax()}`}:${tags[index]}`}>{tags[index]}</span>
         </a>
       </li>
   )) : tags.map((tag) => (
       <li data-cy="tag">
-        <span class="p-1.5 flex gap-1 capitalize opacity-60 hover:opacity-100">
+        <span class="p-1.5 flex gap-1 opacity-60 hover:opacity-100">
           <span>#</span><span data-pagefind-filter={`${`${m.teary_wide_impala_coax()}`}:${tag}`}>{tag}</span>
         </span>
       </li>


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the `CategoryList` and `TagsList` components by removing the 'capitalize' class from the relevant elements.
- This change improves the display of categories and tags by preventing automatic capitalization.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CategoryList.astro</strong><dd><code>Update CategoryList to remove capitalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/post/CategoryList.astro

- Removed 'capitalize' class from category element.



</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/153/files#diff-961aea408f68dfa890a51b25b7cfb4388b932379a584060c6ae482ccf5ea6234">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TagsList.astro</strong><dd><code>Update TagsList to remove capitalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/post/TagsList.astro

- Removed 'capitalize' class from tag links and spans.



</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/153/files#diff-43c5b12e44d9839f5b5ff85ce216efaa9ba6c3c7b505cc49b6c08c59d031ed2f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information