### PR TITLE
fix: Broken RSS link

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -5,7 +5,7 @@ import { shortposts } from '@/utils/getShortposts.ts';
 import sanitizeHtml from 'sanitize-html';
 import MarkdownIt from 'markdown-it';
 import { currentLocaleWebsiteConfig } from '@/utils/getWebsiteConfig.ts';
-import { defaultLocale } from '@/utils/i18n.ts';
+import { defaultLocale, stripLanguageCode, getLocaleCode } from '@/utils/i18n.ts';
 
 const parser = new MarkdownIt();
 const { name, description } = (await currentLocaleWebsiteConfig(defaultLocale)).data.brand;
@@ -18,6 +18,9 @@ export const GET = async (context: APIContext) => {
     site: context.site || '',
     items: [...publishedPosts, ...shortposts].map((collectionItem) => {
       const { slug } = collectionItem;
+      const slugWithoutLocaleCode = stripLanguageCode(slug);
+      const LocaleCode = getLocaleCode(slug);
+
       if (collectionItem.collection === 'shortpost') {
         const { body } = collectionItem;
         const { headline, publishDate, category } = collectionItem.data;
@@ -25,7 +28,7 @@ export const GET = async (context: APIContext) => {
           title: headline,
           content: sanitizeHtml(parser.render(body)),
           pubDate: publishDate,
-          link: `shortpost/${slug}/#${slug}`,
+          link: `${LocaleCode}/shortpost/${slugWithoutLocaleCode}/#${slugWithoutLocaleCode}`,
           categories: [category],
         };
       }
@@ -36,7 +39,7 @@ export const GET = async (context: APIContext) => {
           title: headline,
           description: excerpt,
           pubDate: publishDate,
-          link: `post/${slug}`,
+          link: `${LocaleCode}/post/${slugWithoutLocaleCode}`,
           categories: [category, ...tags],
         };
       }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed broken RSS links by incorporating locale codes into the URLs.
- Improved link formatting for both shortposts and regular posts.
- Added necessary imports for locale code handling.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rss.xml.ts</strong><dd><code>Fix RSS Links to Include Locale Codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/rss.xml.ts

<li>Updated RSS link generation to include locale code.<br> <li> Added utility functions for stripping language codes and getting <br>locale codes.<br> <li> Enhanced link formatting for shortposts and posts.<br>


</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/154/files#diff-6fc674ba1d76d87b8da3bdc314addca9aefaedee21341344324055037009cbd6">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information