### PR TITLE
fix: toc overlaps the page footer

### DIFF
--- a/src/pages/[language]/post/[...slug].astro
+++ b/src/pages/[language]/post/[...slug].astro
@@ -97,7 +97,7 @@ const isSubheadlineEqualHeadline = subHeadline === headline
         <aside 
         style="top: var(--mainNav-height);" class="col-start-3 sticky row-start-2 ml-4 hidden xl:block not-prose">
         
-        <div style="height: calc(100dvh - var(--mainNav-height))" class="absolute top-0 overflow-y-auto divide-y divide-border"> 
+        <div style="height: calc(100dvh - var(--mainNav-height))" class="overflow-y-auto divide-y divide-border"> 
           <PostTableOfContent {headings} />
           {
             postsInSeries.length ? 

--- a/src/pages/post/[...slug].astro
+++ b/src/pages/post/[...slug].astro
@@ -90,7 +90,7 @@ const isSubheadlineEqualHeadline = subHeadline === headline
         <aside 
         style="top: var(--mainNav-height);" class="col-start-3 sticky row-start-2 ml-4 hidden xl:block not-prose">
         
-        <div style="height: calc(100dvh - var(--mainNav-height))" class="absolute top-0 overflow-y-auto divide-y divide-border"> 
+        <div style="height: calc(100dvh - var(--mainNav-height))" class="overflow-y-auto divide-y divide-border"> 
           <PostTableOfContent {headings} />
           {
             postsInSeries.length ? 


### PR DESCRIPTION
Hi @riceball-tw 

I have read your article for a while and hope you doing well :)

Today I came across this [article](https://www.webdong.dev/zh-tw/post/slidev-build-presentation-with-markdown/) and found this weird thing:
<img width="1659" alt="image" src="https://github.com/user-attachments/assets/2c3ffa03-f580-45a6-add6-24df97ac0083" />

I opened the devTool to inspect the element and the root cause is quite clear:
<img width="1659" alt="image" src="https://github.com/user-attachments/assets/8d9e14c7-2cd0-4528-9b76-d6aec1b8cbe6" />

The `absolute` position dropped the TOC off the normal document flow, which caused this problem. Since you have already set the `position` of `aside` to `sticky`, you don't need to set its child as `position: absolute`.

To address this issue, I have removed both `position: absolute` and `top: 0`. It will make sure the `aside` inner contents take up needed space, and no more element overlaps.
<img width="1657" alt="image" src="https://github.com/user-attachments/assets/e89f8200-cad1-47dc-89ef-3333ff067584" />