### PR TITLE
fix: Avoid module init timing issue cause missing localeParams

### DIFF
--- a/src/pages/[language]/index.astro
+++ b/src/pages/[language]/index.astro
@@ -9,7 +9,7 @@ import Container from '@/components/atoms/container/Container.astro';
 import { Badge } from '@/components/atoms/badge/index.ts'
 import { dateSortedLocaleRelatedPosts, sortedPostCategoryies } from '@/utils/getPosts.ts';
 import { currentLocaleWebsiteConfig } from '@/utils/getWebsiteConfig.ts';
-import { stripLanguageCode, localeParams, translateCategory, defaultLocale, type LanguageKey } from '@/utils/i18n.ts';
+import { stripLanguageCode, languages, translateCategory, defaultLocale, type LanguageKey } from '@/utils/i18n.ts';
 import * as m from "@/paraglide/messages";
 import { getRelativeLocaleUrl } from 'astro:i18n';
 
@@ -27,8 +27,10 @@ const currentTime = new Date()
 
 const {currentLocale} = Astro
 
-export async function getStaticPaths() {
-  return localeParams;
+export function getStaticPaths() {
+  return Object.keys(languages).map(language => ({
+    params: { language }
+  }))
 };
 ---
 <BlogBase>

--- a/src/pages/[language]/post/categories/index.astro
+++ b/src/pages/[language]/post/categories/index.astro
@@ -5,12 +5,14 @@ import SpotlightCard from '@/components/atoms/spotlight-card/SpotlightCard.astro
 import SpotlightCardsGallery from '@/components/atoms/spotlight-cards-gallery/SpotlightCardsGallery.astro';
 import Container from '@/components/atoms/container/Container.astro';
 import { sortedPostCategoryies } from '@/utils/getPosts.ts';
-import { localeParams, defaultLocale, translateCategory, type LanguageKey } from '@/utils/i18n.ts';
+import { languages, defaultLocale, translateCategory, type LanguageKey } from '@/utils/i18n.ts';
 import * as m from "@/paraglide/messages";
 import { getRelativeLocaleUrl } from 'astro:i18n';
 
-export async function getStaticPaths() {
-  return localeParams;
+export function getStaticPaths() {
+  return Object.keys(languages).map(language => ({
+    params: { language }
+  }))
 };
 ---
 

--- a/src/pages/[language]/post/index.astro
+++ b/src/pages/[language]/post/index.astro
@@ -6,13 +6,15 @@ import SpotlightPostCard from '@/components/atoms/spotlight-post-card/SpotlightP
 import { Badge } from '@/components/atoms/badge/index.ts'
 import Container from '@/components/atoms/container/Container.astro';
 import { dateSortedLocaleRelatedPosts, sortedPostCategoryies, sortedPostTags } from '@/utils/getPosts.ts';
-import { localeParams, defaultLocale } from '@/utils/i18n.ts';
+import { languages, defaultLocale } from '@/utils/i18n.ts';
 import * as m from "@/paraglide/messages";
 import { getRelativeLocaleUrl } from 'astro:i18n';
 import { type LanguageKey } from '@/utils/i18n.ts';
 
-export async function getStaticPaths() {
-  return localeParams;
+export function getStaticPaths() {
+  return Object.keys(languages).map(language => ({
+    params: { language }
+  }))
 };
 
 const posts = dateSortedLocaleRelatedPosts(Astro.currentLocale as LanguageKey);

--- a/src/pages/[language]/post/tags/index.astro
+++ b/src/pages/[language]/post/tags/index.astro
@@ -5,12 +5,14 @@ import SpotlightCard from '@/components/atoms/spotlight-card/SpotlightCard.astro
 import SpotlightCardsGallery from '@/components/atoms/spotlight-cards-gallery/SpotlightCardsGallery.astro';
 import Container from '@/components/atoms/container/Container.astro';
 import { sortedPostTags } from '@/utils/getPosts.ts';
-import { localeParams, defaultLocale } from '@/utils/i18n.ts';
+import { languages, defaultLocale } from '@/utils/i18n.ts';
 import * as m from "@/paraglide/messages";
 import { getRelativeLocaleUrl } from 'astro:i18n';
 
-export async function getStaticPaths() {
-  return localeParams;
+export function getStaticPaths() {
+  return Object.keys(languages).map(language => ({
+    params: { language }
+  }))
 };
 ---
 

--- a/src/pages/[language]/shortpost/index.astro
+++ b/src/pages/[language]/shortpost/index.astro
@@ -4,13 +4,16 @@ import Hero from '@/components/molecules/hero/Hero.astro';
 import ShortpostList from '@/components/atoms/shortpost-list/ShortpostList.astro'
 import Container from '@/components/atoms/container/Container.astro';
 import * as m from "@/paraglide/messages";
-import { localeParams } from '@/utils/i18n.ts';
+import { languages } from '@/utils/i18n.ts';
 import { dateSortedLocaleRelatedShortposts } from '@/utils/getShortposts.ts';
 import { type LanguageKey } from '@/utils/i18n.ts';
 
-export async function getStaticPaths() {
-  return localeParams;
+export function getStaticPaths() {
+  return Object.keys(languages).map(language => ({
+    params: { language }
+  }))
 };
+
 const shortposts = dateSortedLocaleRelatedShortposts(Astro.currentLocale as LanguageKey);
 ---
 

--- a/src/pages/[language]/toolbox.astro
+++ b/src/pages/[language]/toolbox.astro
@@ -7,7 +7,7 @@ import Navbar from '@/components/organisms/global-navbar/GlobalNavbar.astro';
 import YoutubeChannels from '@/components/molecules/youtube-channels/YoutubeChannels.astro';
 import Container from '@/components/atoms/container/Container.astro';
 import { toolboxs } from '@/utils/getToolboxs.ts';
-import { localeParams } from '@/utils/i18n.ts';
+import { languages } from '@/utils/i18n.ts';
 import * as m from "@/paraglide/messages";
 
 const categorizedSites = toolboxs.reduce((categorizedData: Record<string, any[]>, site) => {
@@ -175,8 +175,10 @@ const youtubeChannelInfos = [
 
 const youtubeChannels = await getYoutubeChannels(youtubeChannelInfos);
 
-export async function getStaticPaths() {
-  return localeParams;
+export function getStaticPaths() {
+  return Object.keys(languages).map(language => ({
+    params: { language }
+  }))
 };
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ import Container from '@/components/atoms/container/Container.astro';
 import { Badge } from '@/components/atoms/badge/index.ts'
 import { dateSortedLocaleRelatedPosts, sortedPostCategoryies } from '@/utils/getPosts.ts';
 import { currentLocaleWebsiteConfig } from '@/utils/getWebsiteConfig.ts';
-import { stripLanguageCode, localeParams, translateCategory, type LanguageKey , defaultLocale} from '@/utils/i18n.ts';
+import { stripLanguageCode, translateCategory, type LanguageKey , defaultLocale} from '@/utils/i18n.ts';
 import * as m from "@/paraglide/messages";
 import { getRelativeLocaleUrl } from 'astro:i18n';
 
@@ -26,10 +26,6 @@ const currentTime = new Date()
   .replace(/\//g, '-');
 
 const {currentLocale} = Astro
-
-export async function getStaticPaths() {
-  return localeParams;
-};
 ---
 <BlogBase>
   <slot name="head">

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -30,15 +30,6 @@ export const prefixDefaultLocale = false;
 export type LanguageKey = keyof typeof languages;
 export type LanguageValue = (typeof languages)[LanguageKey];
 
-/**
- * Get locale parms for Astro's `getStaticPaths` function
- * @returns - The list of locale params
- * @see https://docs.astro.build/en/guides/routing/#dynamic-routes
- */
-export const localeParams = Object.keys(languages).map((language) => ({
-  params: { language },
-}));
-
 export function stripLanguageCode(str: string) {
   return str.replace(/^[a-z]{2}(-[a-z]{2})?\//i, '');
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove `localeParams` to fix timing issue

- Update `getStaticPaths` to use languages

- Ensure consistent locale handling across pages


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>i18n.ts</strong><dd><code>Remove localeParams and update language handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/180/files#diff-648766b39e18e48addc4d75d1e8c92235f724796ffb67e8e84d8b08aaf437faa">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.astro</strong><dd><code>Use languages instead of localeParams</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/180/files#diff-6f1eed70bb86517e996cab85c9e249d9f0a0aeb4ae9f6d488cbdff17ca753e8a">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.astro</strong><dd><code>Update static paths to use languages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/180/files#diff-9114cbda94ac81daa92c0776702fb2f968877297b589743f4f819be466baf5ed">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.astro</strong><dd><code>Modify getStaticPaths to use languages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/180/files#diff-34820faa106ddcb6ded4e31c7b430ec1f2aca877238b5cf4adfe46fe9bb2898e">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.astro</strong><dd><code>Change static paths to use languages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/180/files#diff-65fda72513f19a4ae0065c0a7fdf14b58a2aa72aab6583c9a668780ad3ee30e7">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.astro</strong><dd><code>Update static paths to use languages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/180/files#diff-31809bdccf3a35203393e925d2b94a657959ade201e84a2cd6eaa39bc3489dbd">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>toolbox.astro</strong><dd><code>Modify getStaticPaths to use languages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/180/files#diff-67f7f37965de8ca0521616e728e7e677ea8ea63a5c14027550a94c48ac97c47f">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.astro</strong><dd><code>Remove localeParams and clean imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/180/files#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>