### PR TITLE
fix: Missing default locale pagefind index

### DIFF
--- a/src/components/atoms/shortpost-list/ShortpostList.astro
+++ b/src/components/atoms/shortpost-list/ShortpostList.astro
@@ -8,10 +8,9 @@ import * as m from "@/paraglide/messages";
 export type Props = {
   shortposts: ShortpostPage[]
   currentSlug?: string
-  isSearchAble?: boolean
 } 
 
-const { shortposts, currentSlug, isSearchAble } = Astro.props
+const { shortposts, currentSlug } = Astro.props
 const activeShortpostIndexs = shortposts.findIndex((shortpost) => shortpost.slug === currentSlug)
 ---
 <ul class="space-y-4 md:space-y-8">
@@ -31,7 +30,8 @@ const activeShortpostIndexs = shortposts.findIndex((shortpost) => shortpost.slug
       <li class="flex text-xl md:text-2xl gap-2 md:gap-4">
         {/* Index */}
         <div class={`hidden sm:block ${isActiveShort ? 'font-bold' : ''}`}>#{shortposts.length - index}</div>
-        <div class="w-full" data-pagefind-body={isSearchAble && isActiveShort  || undefined}>
+        {/* When it's falsy value, || undefined is necessary for hide whole attribute, to avoid pagefind index  */}
+        <div class="w-full" data-pagefind-body={isActiveShort || undefined}>
           {/* Title */}
           <a class={`hover:opacity-100 
             ${isActiveShort ? 'opacity-100 mb-4 inline-block' : ''}

--- a/src/pages/[language]/post/[...slug].astro
+++ b/src/pages/[language]/post/[...slug].astro
@@ -64,7 +64,7 @@ const isSubheadlineEqualHeadline = subHeadline === headline
   <Container>
     <main class="mt-0 pt-8 px-2 sm:mt-[var(--mainNav-height)]">
       <article
-        data-pagefind-body={Astro.currentLocale !== defaultLocale || undefined}
+        data-pagefind-body={Astro.currentLocale}
         data-article
         data-cy="post-content"
         class=`article-grid [grid-template-columns:1fr_min(65ch,_100%)_1fr] lg:px-auto prose mb-16 block w-full max-w-none md:prose-xl lg:grid ${rehypeAutoLinkStyle}`

--- a/src/pages/[language]/shortpost/[...slug].astro
+++ b/src/pages/[language]/shortpost/[...slug].astro
@@ -30,7 +30,7 @@ const createExcerpt = (body: string, maxLength: number = 160) => markdownParser.
 <BlogBase title={headline} description={createExcerpt(shortpost.body)} thumbnail={{ src: `/shortpost/${shortpost.slug}`, alt: `${headline}` }}>
   <Container>
     <main style={leaveSpaceforLastShortStyle} class="mt-0 pt-8 sm:mt-[var(--mainNav-height)]">
-      <ShortpostList isSearchAble={Astro.currentLocale !== defaultLocale} shortposts={shortposts} currentSlug={shortpost.slug}>
+      <ShortpostList shortposts={shortposts} currentSlug={shortpost.slug}>
         <Content components={{ img: PostImage }}  />
       </ShortpostList>
     </main>

--- a/src/pages/[language]/shortpost/[...slug].astro
+++ b/src/pages/[language]/shortpost/[...slug].astro
@@ -5,7 +5,7 @@ import PostImage from '@/components/atoms/post-image/PostImage.astro';
 import MarkdownIt from 'markdown-it';
 import Container from '@/components/atoms/container/Container.astro';
 import { dateSortedLocaleRelatedShortposts } from '@/utils/getShortposts.ts';
-import { languages, stripLanguageCode, type LanguageKey, defaultLocale } from '@/utils/i18n.ts';
+import { languages, stripLanguageCode, type LanguageKey } from '@/utils/i18n.ts';
 
 export async function getStaticPaths() {
   return Object.keys(languages).flatMap((language) => dateSortedLocaleRelatedShortposts(language as LanguageKey).map((shortpost) => ({


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove unnecessary `isSearchAble` prop

- Fix `data-pagefind-body` attribute handling

- Ensure proper locale handling in components


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ShortpostList.astro</strong><dd><code>Update ShortpostList component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/atoms/shortpost-list/ShortpostList.astro

<li>Removed <code>isSearchAble</code> prop from component<br> <li> Adjusted <code>data-pagefind-body</code> attribute logic


</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/182/files#diff-29d20e5b6de498a30d0a5b8842bfb6bc94451b0b195fd86a71c71c8d7905874f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>[...slug].astro</strong><dd><code>Refine post page locale handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/[language]/post/[...slug].astro

- Simplified `data-pagefind-body` logic


</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/182/files#diff-38c34f86b269b29bbac255d73a7d8b1e0a5dd57996c85e9777177d01da7baf5f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>[...slug].astro</strong><dd><code>Update shortpost page component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/[language]/shortpost/[...slug].astro

- Removed `isSearchAble` prop from ShortpostList


</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/182/files#diff-7d8d499baed73dec15f6e95420849c82ba0cd24415db1294cc4f25cacf04eb66">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>