### PR TITLE
fix: Same toc title cause multiple active item

### DIFF
--- a/src/components/atoms/post-toc/PostTableOfContent.astro
+++ b/src/components/atoms/post-toc/PostTableOfContent.astro
@@ -62,25 +62,27 @@ const { headings } = Astro.props
 </style>
 
 <script>
-  function setTocObserver() {
-    const tocLinks = document.querySelectorAll('[data-toc-link]');
-    const observerOptions = { threshold: 1, rootMargin: '-5% 0% -5% 0%'}
-    return new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          tocLinks.forEach((link) => {
-            const isHeadingAndTocLinkContentMatched = entry.target.textContent === link?.textContent?.trim()
-            link.classList.remove('toc-active-link');
-            link.classList.add('toc-link');
-            if (isHeadingAndTocLinkContentMatched) {
-              link.classList.add('toc-active-link');
-              link.classList.remove('toc-link');
-            }
-          });
-        }
-      });
-    }, observerOptions);
-  }
+function setTocObserver() {
+  const tocLinks = document.querySelectorAll('[data-toc-link]');
+  const observerOptions = { threshold: 1, rootMargin: '-5% 0% -5% 0%' }
+
+  return new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        tocLinks.forEach((link) => {
+          if (!(link instanceof HTMLAnchorElement)) return;
+          const isMatched = decodeURIComponent(link.hash.slice(1)) === entry.target.id;
+          link.classList.remove('toc-active-link');
+          link.classList.add('toc-link');
+          if (isMatched) {
+            link.classList.add('toc-active-link');
+            link.classList.remove('toc-link');
+          }
+        });
+      }
+    });
+  }, observerOptions);
+}
 
   function tocInit() {
     const avaliableHeadings = document.querySelectorAll<HTMLHeadingElement>('[data-article] h2, h3');


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Update TOC active item logic

- Match active item by heading ID

- Improve IntersectionObserver functionality


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PostTableOfContent.astro</strong><dd><code>Refactor TOC active item detection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/atoms/post-toc/PostTableOfContent.astro

<li>Refactor setTocObserver function<br> <li> Change active link matching from title to ID<br> <li> Ensure links are HTMLAnchorElement before processing


</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/197/files#diff-ede1ffb0e82cda062ddc5c85b4268f1520b9353e5b93b61a483df440559caa10">+21/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>