### PR TITLE
fix: Better homepage heading dragging experience

### DIFF
--- a/src/pages/[language]/index.astro
+++ b/src/pages/[language]/index.astro
@@ -48,7 +48,22 @@ export function getStaticPaths() {
         <div>
           <!-- Design -->
           <span class="relative inline-flex">
-            <span id="draggable" class="translate-y-2 hover:-rotate-2 inline-flex items-center gap-2 border lg:border-2 p-1 pr-2 border-current/60 whitespace-nowrap cursor-grab hover:bg-primary/20 hover:text-primary transition">
+            <!-- !Hack: Since change element to absolute will cause layout rebuild and weird first grab position, so I create 2 same element here, one is invisible for layout, another one is absolute positioned for user to grab -->
+            <!-- Placeholder -->
+            <span class="invisible translate-y-2 hover:-rotate-2 inline-flex items-center gap-2 border lg:border-2 p-1 pr-2 border-current/60 whitespace-nowrap cursor-grab hover:bg-primary/20 hover:text-primary transition">
+              <Icon class="lg:inline" style="width: 5vw; height:5vw; max-width: 84px; max-height: 84px; min-width: 48px; min-height: 48px;" size={32} name={'material-symbols:edit-document-outline-rounded'}  />
+              {m.nice_equal_wallaby_slide()}
+              <span class="absolute top-0 left-0 -translate-x-1/2 -translate-y-1/2 size-1 lg:size-2 bg-current/60"></span>
+              <span class="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 size-1 lg:size-2 bg-current/60"></span>
+              <span class="absolute top-0 right-0 translate-x-1/2 -translate-y-1/2 size-1 lg:size-2 bg-current/60"></span>
+              <span class="absolute top-1/2 -translate-x-1/2 left-0 size-1 lg:size-2 bg-current/60"></span>
+              <span class="absolute top-1/2 right-0 translate-x-1/2 size-1 lg:size-2 bg-current/60"></span>
+              <span class="absolute bottom-0 left-0 -translate-x-1/2 translate-y-1/2 size-1 lg:size-2 bg-current/60"></span>
+              <span class="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 size-1 lg:size-2 bg-current/60"></span>
+              <span class="absolute bottom-0 right-0 translate-x-1/2 translate-y-1/2 size-1 lg:size-2 bg-current/60"></span>
+            </span>
+            <!-- Real -->
+            <span id="draggable" class="absolute translate-y-2 hover:-rotate-2 inline-flex items-center gap-2 border lg:border-2 p-1 pr-2 border-current/60 whitespace-nowrap cursor-grab hover:bg-primary/20 hover:text-primary transition">
               <Icon class="lg:inline" style="width: 5vw; height:5vw; max-width: 84px; max-height: 84px; min-width: 48px; min-height: 48px;" size={32} name={'material-symbols:edit-document-outline-rounded'}  />
               {m.nice_equal_wallaby_slide()}
               <span class="absolute top-0 left-0 -translate-x-1/2 -translate-y-1/2 size-1 lg:size-2 bg-current/60"></span>

--- a/src/pages/[language]/index.astro
+++ b/src/pages/[language]/index.astro
@@ -150,6 +150,7 @@ export function getStaticPaths() {
   
   let posX = 0;
   let posY = 0;
+  const grabbingStyle = ['bg-primary/20', 'text-primary', '-rotate-2']
   
   function getClientX(e) {
     return e.touches ? e.touches[0].clientX : e.clientX;
@@ -169,17 +170,17 @@ export function getStaticPaths() {
   
   function dragStart(e) {
     e.preventDefault();
-    draggable.style.position = 'absolute';
     draggable.style.cursor = 'grabbing';
+    draggable.classList.add(...grabbingStyle);
     posX = getClientX(e) - draggable.offsetLeft;
     posY = getClientY(e) - draggable.offsetTop;
   
     window.addEventListener('mousemove', moveElement, false);
     window.addEventListener('touchmove', moveElement, { passive: false });
   }
-  
   function dragEnd() {
     draggable.style.cursor = 'grab';
+    draggable.classList.remove(...grabbingStyle);
     window.removeEventListener('mousemove', moveElement, false);
     window.removeEventListener('touchmove', moveElement, false);
   }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix first drag position issue

- Improve touch drag styling

- Add invisible placeholder for layout


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.astro</strong><dd><code>Fix drag behavior and enhance styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/[language]/index.astro

<li>Fixed weird first drag position<br> <li> Added touch drag styles<br> <li> Introduced invisible placeholder for layout


</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/207/files#diff-6f1eed70bb86517e996cab85c9e249d9f0a0aeb4ae9f6d488cbdff17ca753e8a">+19/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>