### PR TITLE
fix: 404 on PWA start url

### DIFF
--- a/src/pages/manifest.webmanifest.ts
+++ b/src/pages/manifest.webmanifest.ts
@@ -15,7 +15,7 @@ export const GET: APIRoute = () =>
         { src: 'images/brand/favicon/icon-512.png', type: 'image/png', sizes: '512x512' },
         { src: 'images/brand/favicon/maskable-icon-512.png', type: 'image/png', sizes: '512x512', purpose: 'maskable' },
       ],
-      start_url: '/post',
+      start_url: '/',
       display: 'fullscreen',
       theme_color: themeColor,
       background_color: themeColor,


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fix 404 error on PWA start URL

- Update `start_url` to root path


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Update PWA start URL"] -- "Fixes" --> B["404 Error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.webmanifest.ts</strong><dd><code>Update PWA start URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/manifest.webmanifest.ts

- Changed `start_url` from '/post' to '/'


</details>


  </td>
  <td><a href="https://github.com/riceball-tw/web-dong-blog/pull/222/files#diff-2026ae42913d3a75e13884d969bf7c94788e063b7147b1f13e2162e836c8a0d1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

